### PR TITLE
Went on a Docker diet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM python:3.10
+FROM python:3-alpine
 
 WORKDIR /code
 
 COPY  ./requirements.txt /code/requirements.txt
 
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+RUN apk update && apk add --no-cache postgresql-dev gcc python3-dev musl-dev g++ && \
+  pip install --no-cache-dir --upgrade -r /code/requirements.txt && \
+  apk del gcc python3-dev musl-dev g++
 
 COPY ./entry_point.sh /entry_point.sh
 RUN chmod +x /entry_point.sh


### PR DESCRIPTION
Managed to reduce Docker from 943 MB to 402 MB, Please notice that the order of commands have changed and now the `pip` command is wrapped with `apk add` above and `apk del` below, this will ensure the dependencies for building the `pip` wheels will not be part of the Docker layer so that less space is required (posrgresql-dev is required).

Also our Snyk score should be improved drastically with this change.