### PR TITLE
Træfik implementation and small usability fixes

### DIFF
--- a/db_init/baseline.sql
+++ b/db_init/baseline.sql
@@ -56,3 +56,8 @@ INSERT INTO event_log(event_timestamp,guard_id,event_type,amount_before,amount_a
 VALUES
 	(NOW(),'ce170212-7242-4f56-9298-d84b521eaedd','entered',4,5),
 	(NOW(),'c397aebd-9cfe-47d1-9f1c-75aab323daf5','cancelled',3,4);
+
+INSERT INTO invitations(invitation_id,user_id,invitees_amount,invitees_admitted,invitees_arrival_timestamp,is_active,creation_timestamp,modify_timestamp,comment_for_guard)
+values
+    ('ce170212-7242-4f56-9297-d84b528eaedd','c397aebd-9cfe-47d1-9f1c-75aab323daf5',8,6,NOW(),True,NOW(),NOW(),'Hey there'),
+    ('ce170212-7242-4f56-9297-d84b528ea0fd','ce170212-7242-4f56-9298-d84b521eaedd',10,7,NOW(),True,NOW(),NOW(),'Hey Itzik')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,20 @@ services:
     build: .
     volumes:
       - ./src:/code/src
-    ports:
-      - 8080:8080
+    networks:
+      - web
     depends_on:
       - "db"
+      - "keycloak"
     environment:
        IVT_OPENID_DISCOVERY_URL: 'http://keycloak:8080/auth/realms/master/.well-known/openid-configuration'
        #IVT_ENABLE_AUTH: 'true'
+    labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.invitease.rule=Host(`invitease.localhost`)"
+    - "traefik.http.routers.invitease.entrypoints=web"
+    - "traefik.docker.network=web"
+    - "traefik.http.services.invitease.loadbalancer.server.port=8090"
 
   db:
     image: postgres:14-alpine
@@ -21,16 +28,17 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=invitease
       - POSTGRES_DB=invitease
-    ports:
-      - 5432:5432
+    networks:
+      - web
     volumes:
       - ./db_init/:/docker-entrypoint-initdb.d/
       - pg_data:/var/lib/postgresql/data
+
   keycloak:
     image: bitnami/keycloak:15.0.2
     hostname: keycloak
-    ports:
-      - "8081:8080"
+    networks:
+      - web
     depends_on:
       - db
     environment:
@@ -40,5 +48,43 @@ services:
       - KEYCLOAK_DATABASE_USER=invitease
       - KEYCLOAK_DATABASE_PASSWORD=password
       - KEYCLOAK_DATABASE_NAME=keycloak
+      - KEYCLOAK_FRONTEND_URL=keycloak.localhost
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.keycloak.rule=Host(`keycloak.localhost`)"
+      - "traefik.http.routers.keycloak.entrypoints=web"
+      - "traefik.docker.network=web"
+      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
+
+
+  traefik:
+    image: traefik:v2.5.4
+    command:
+      - "--log.level=DEBUG"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.traefik.address=:8081"
+    depends_on:
+      - "app"
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dashboard.rule=Host(`dash.localhost`)"
+      - "traefik.http.routers.dashboard.entrypoints=web"
+      - "traefik.http.routers.dashboard.service=api@internal"
+    ports:
+      - "80:80"
+      #- "8081:8081" # The Web UI (enabled by --api)
+    networks:
+      - web
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+networks:
+  web:
+    driver: bridge
+
 volumes:
   pg_data:        

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
-      - "--entrypoints.traefik.address=:8081"
     depends_on:
       - "app"
     restart: always
@@ -76,7 +75,6 @@ services:
       - "traefik.http.routers.dashboard.service=api@internal"
     ports:
       - "80:80"
-      #- "8081:8081" # The Web UI (enabled by --api)
     networks:
       - web
     volumes:

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 cd src
-uvicorn main:app --host 0.0.0.0 --port 8080
+uvicorn main:app --host 0.0.0.0 --port 8090

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,4 +1,4 @@
 from database.users_repository import UsersRepository
-from database.invitation_list import InvitationRepository
+from database.invitation_repository import InvitationRepository
 from database.connection import create_connection
 from database.models import User, Invitation, EventLogEntry

--- a/src/routers/inviter_router.py
+++ b/src/routers/inviter_router.py
@@ -1,3 +1,12 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from database import InvitationRepository, create_connection, models, Invitation
 
 router = APIRouter(prefix="/inviter", tags=["inviter"])
+
+def create_invitations_list():
+    connection = create_connection()
+    return InvitationRepository(connection)
+
+@router.get("/invitations", summary="Gets all the invitations for this user.")
+def get_invitations(invitations: InvitationRepository = Depends(create_invitations_list), user_id: str = None):
+    return invitations.query(lambda x: x.filter(Invitation.user_id == user_id))

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,4 +1,9 @@
-from database import UsersRepository, create_connection
+from starlette.middleware.base import BaseHTTPMiddleware
+from database import UsersRepository, InvitationRepository, create_connection
+from fastapi import Request, Response
+import requests
+
+allowed_paths = ('/docs', '/openapi.json')
 
 
 def create_users_repository():


### PR DESCRIPTION
A fairly complex fix that masks all the services behind a single endpoint that can be diverted upon request.

Currently we have:

- invitease.localhost
- keycloak.localhost
- dash.localhost

All of them can be converted to:

- invitease.localhost
- invitease.localhost/keycloak
- invitease.localhost/dash

Binding these all under the same domain as required by @inbarbarkai 

Closes #40 
